### PR TITLE
Replace clunky `->` with real arrows

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Third, install Oh My Zsh. "Oh My Zsh is a delightful, open source, community-dri
 Dotfiles
 --------
 
-Requires token via GitHub -> Settings -> Developer settings -> Personal access tokens
+Requires token via GitHub → Settings → Developer settings → Personal access tokens
 
 ::
 
@@ -94,17 +94,17 @@ Install Chrome extensions
 Modify Chrome settings
 ~~~~~~~~~~~~~~~~~~~~~~
 
-- Settings -> Appearance -> Show home button [*]
-- Settings -> Autofill -> Passwords -> Offer to save passwords []
-- Settings -> Autofill -> Passwords -> Auto Sign-in []
-- Settings -> Autofill -> Payment methods -> Save and fill payment methods []
-- Settings -> Autofill -> Payment methods -> Allow sites to check if you have payment methods saved []
-- Settings -> Autofill -> Addresses and more -> Save and fill addresses []
+- Settings → Appearance → Show home button [*]
+- Settings → Autofill → Passwords → Offer to save passwords []
+- Settings → Autofill → Passwords → Auto Sign-in []
+- Settings → Autofill → Payment methods → Save and fill payment methods []
+- Settings → Autofill → Payment methods → Allow sites to check if you have payment methods saved []
+- Settings → Autofill → Addresses and more → Save and fill addresses []
 
 Modify Outlook settings
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-- Outlook -> Organize -> Focused Inbox []
+- Outlook → Organize → Focused Inbox []
 
 Modify System Preferences
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -112,52 +112,52 @@ Modify System Preferences
 Accessibility
 +++++++++++++
 
-- Accessibility -> Zoom -> [*] Use scroll gesture with modifier keys to zoom: ^Control
+- Accessibility → Zoom → [*] Use scroll gesture with modifier keys to zoom: ^Control
 
 Dock
 ++++
 
-- Dock -> [] Show recent applications in Dock
+- Dock → [] Show recent applications in Dock
 
 Energy Saver
 ++++++++++++
 
-- Battery -> [] Put hard disks to sleep when possible
-- Battery -> [] Slightly dim the display when on battery power
-- Battery -> Turn display off after [Never]
-- Power Adapter -> [] Put hard disks to sleep when possible
-- Power Adapter -> [] Slightly dim the display when on battery power
-- Power Adapter -> Turn display off after [Never]
+- Battery → [] Put hard disks to sleep when possible
+- Battery → [] Slightly dim the display when on battery power
+- Battery → Turn display off after [Never]
+- Power Adapter → [] Put hard disks to sleep when possible
+- Power Adapter → [] Slightly dim the display when on battery power
+- Power Adapter → Turn display off after [Never]
 
 Keyboard
 ++++++++
 
-- Keyboard -> [*] Show keyboard and emoji viewers in menu bar
-- Shortcuts -> Mission Control -> [*] Move left a space [CMD<-]
-- Shortcuts -> Mission Control -> [*] Move right a space [CMD->]
+- Keyboard → [*] Show keyboard and emoji viewers in menu bar
+- Shortcuts → Mission Control → [*] Move left a space [CMD<-]
+- Shortcuts → Mission Control → [*] Move right a space [CMD→]
 
 Mission Control
 +++++++++++++++
 
-- Mission Control -> Keyboard and Mouse Shortcuts -> Mission Control -> Middle Mouse Button
-- Mission Control -> [] Displays have separate spaces
+- Mission Control → Keyboard and Mouse Shortcuts → Mission Control → Middle Mouse Button
+- Mission Control → [] Displays have separate spaces
 
 Security & Privacy 
 ++++++++++++++++++
 
-- Security & Privacy -> General -> A login password has been set for this user -> [] Require password ________ after sleep or screen saver begins
+- Security & Privacy → General → A login password has been set for this user → [] Require password ________ after sleep or screen saver begins
 
 Trackpad
 ++++++++
 
-- Trackpad -> More Gestures -> [] Swipe between pages
+- Trackpad → More Gestures → [] Swipe between pages
 
 Users & Groups
 ++++++++++++++
 
-- Users & Groups -> Alex Clark -> Login Items -> + pCloud Drive
-- Users & Groups -> Alex Clark -> Login Items -> + Jumpcut
-- Users & Groups -> Login Options -> Automatic Login -> Alex Clark
+- Users & Groups → Alex Clark → Login Items → + pCloud Drive
+- Users & Groups → Alex Clark → Login Items → + Jumpcut
+- Users & Groups → Login Options → Automatic Login → Alex Clark
 
 Modify Terminal Preferences
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -176,24 +176,24 @@ Text
 '''''
 
 - CMD + + + + +
-- Terminal -> Shell -> Use Settings as Default
+- Terminal → Shell → Use Settings as Default
 
 Window
 '''''''''
 
-- 80x24 -> 120x36
-- Terminal -> Shell -> Use Settings as Default
+- 80x24 → 120x36
+- Terminal → Shell → Use Settings as Default
 
 Shell
 '''''
 
-- Terminal -> Preferences -> Profile -> Default -> Shell -> When the shell exits: [Close the window]
-- Terminal -> Preferences -> Profile -> Default -> Shell -> Ask before closing: [Never]
+- Terminal → Preferences → Profile → Default → Shell → When the shell exits: [Close the window]
+- Terminal → Preferences → Profile → Default → Shell → Ask before closing: [Never]
 
 Advanced
 '''''''''
 
-- Terminal -> Preferences -> Profile -> Default -> Advanced -> Bell -> [] Audible bell 
-- Terminal -> Preferences -> Profile -> Default -> Advanced -> Bell -> [] Visual bell 
-- Terminal -> Preferences -> Profile -> Default -> Advanced -> Bell -> [] Badge app and window Dock 
-- Terminal -> Preferences -> Profile -> Default -> Advanced -> Bell -> [] Bounce app icon when in background 
+- Terminal → Preferences → Profile → Default → Advanced → Bell → [] Audible bell 
+- Terminal → Preferences → Profile → Default → Advanced → Bell → [] Visual bell 
+- Terminal → Preferences → Profile → Default → Advanced → Bell → [] Badge app and window Dock 
+- Terminal → Preferences → Profile → Default → Advanced → Bell → [] Bounce app icon when in background 


### PR DESCRIPTION
Merge this (if you dare) and get rid of 1960's era ASCII `->` and have genuine Unicode arrows `→`.

It's 2020. Come on, man 😉